### PR TITLE
Fix devices for torchaudio=0.7.0

### DIFF
--- a/sandbox/util_frontend.py
+++ b/sandbox/util_frontend.py
@@ -154,7 +154,7 @@ class LFCC(torch_nn.Module):
         
         # STFT
         x_stft = torch.stft(x, self.fn, self.fs, self.fl, 
-                            window=torch.hamming_window(self.fl), 
+                            window=torch.hamming_window(self.fl).to(x.device), 
                             onesided=True, pad_mode="constant")        
         # amplitude
         sp_amp = torch.norm(x_stft, 2, -1).pow(2).permute(0, 2, 1).contiguous()


### PR DESCRIPTION
Posting here in case somebody wants to use newer Torch and/or torchaudio.
**No testing done to ensure everything else works, only running projects/02-asvspoof/lfcc-lcnn-sigmoid/00_demo.sh**

For some reason with torchaudio 0.7 the line in question complains about incorrect devices. Conveniently enough torchaudio does not have extensive changelog, so I am not sure if they fixed something in their code (seems like they removed some automagical moving).

